### PR TITLE
Support for `cd -` to change to previous dir

### DIFF
--- a/README
+++ b/README
@@ -28,7 +28,7 @@ $ cargo run --release -- -c "echo this is an example"
   + cd
     * changing directories with relative/exact paths [done]
     * cd without args takes you $HOME [done]
-    * cd with '-' takes you to previous dir 
+    * cd with '-' takes you to previous dir [done (can't use cd - two times in a row, stays in same dir)]
       (for more context see https://github.com/Phate6660/crusty/pull/4#issuecomment-908802180)
   + echo
     + basic echo functions [done]

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -62,6 +62,8 @@ pub fn cd(shell_state: &mut ShellState, input: &str) {
             println!("No previous dir found");
             return
         }
+        // unwrap can be safely used here, because function would've returned
+        // if cd_prev_dir is None
         match &shell_state.cd_prev_dir.as_ref().unwrap().to_str() {
             Some(path) => cd_helper(path),
             None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,11 @@ use shared_functions::{cmd, ShellState, non_interactive, piped_cmd, piped_text};
 use shared_functions::parse_input;
 
 // Process the input to run the appropriate builtin or external command.
-fn process_input(_shell_state: &mut ShellState, input: String) {
+fn process_input(shell_state: &mut ShellState, input: String) {
     if input.starts_with("calc") {
         calc(&input);
     } else if input.starts_with("cd") {
-        cd(&input);
+        cd(shell_state, &input);
     } else if input.starts_with("echo") {
         echo(&input);
     } else if input.starts_with("help") {


### PR DESCRIPTION
So, this time I got it right, I hope.
It still isn't 100%, because you can't use `cd -` directly followed by a `cd -`, because then you just stay in the same dir.
This is, because the information about the previous dir in the code to change the dir on a `cd -` is stored after the change, so the previous dir is the dir after the change.
I probably will fix this in the future, but just wanted to get the almost done version out there.