### PR TITLE
Shellcommand

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -105,9 +105,18 @@ pub fn echo(command: ShellCommand) {
     //}
 }
 
-fn ls_do(input: &str) {
+fn ls_do(args: Vec<String>) {
     let mut t = term::stdout().unwrap();
+    let mut path_idx = 0;
 
+    for (idx, arg) in args.iter().enumerate() {
+        if !arg.starts_with("--") || !arg.starts_with("-") {
+            path_idx = idx;
+        }
+    }
+
+
+    let input = &args[path_idx];
     let path;
     if std::path::Path::new(input).exists() {
         path = std::fs::read_dir(input).unwrap()
@@ -156,9 +165,9 @@ fn ls_do(input: &str) {
     }
 }
 
-pub fn ls(input: &str) {
-    if input == "ls" {
-        ls_do(".");
+pub fn ls(command: ShellCommand) {
+    if command.args.len() <= 0 {
+        ls_do(vec![".".to_string()]);
     }/* else if input.contains('|') {
         let ls_input = input.split('|').collect::<Vec<&str>>()[0];
         let path = if ls_input.trim() == "ls" {
@@ -197,8 +206,7 @@ pub fn ls(input: &str) {
             piped_text(&output, false, cmd);
         }*/
     else {
-        let input = input.split(' ').collect::<Vec<&str>>()[1];
-        ls_do(input);
+        ls_do(command.args);
     }
 }
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -78,7 +78,7 @@ pub fn cd(shell_state: &mut ShellState, command: ShellCommand) {
     }
 }
 
-pub fn echo(input: &str) {
+pub fn echo(command: ShellCommand) {
     /*if input.contains('|') {
         let line_vector: Vec<&str> = input.split('|').collect();
         let cmd = line_vector[0];
@@ -97,9 +97,7 @@ pub fn echo(input: &str) {
             piped_text(&message, false, cmd2_with_args);
         }
     } else {*/
-        let input: Vec<&str> = input.split(' ').collect();
-        let output = &input[1..];
-        for arg in output {
+        for arg in command.args {
             print!("{} ", arg);
             std::io::stdout().flush().unwrap();
         }

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -51,13 +51,13 @@ fn cd_helper(dir: &str) {
     }
 }
 
-pub fn cd(shell_state: &mut ShellState, input: &str) {
-    if input == "cd" {
+pub fn cd(shell_state: &mut ShellState, command: ShellCommand) {
+    if command.args.len() <= 0 {
         shell_state.cd_prev_dir = Some(std::env::current_dir().unwrap().to_owned());
         let user = std::env::var("USER").unwrap();
         let home = ["/home/", user.as_str()].concat();
         cd_helper(&home);
-    } else if input == "cd -" {
+    } else if command.args[0] == "-" {
         if shell_state.cd_prev_dir.is_none() {
             println!("No previous dir found");
             return
@@ -74,8 +74,7 @@ pub fn cd(shell_state: &mut ShellState, input: &str) {
         shell_state.cd_prev_dir = Some(std::env::current_dir().unwrap().to_owned());
     } else {
         shell_state.cd_prev_dir = Some(std::env::current_dir().unwrap().to_owned());
-        let input = input.split(' ').collect::<Vec<&str>>()[1];
-        cd_helper(input);
+        cd_helper(&command.args[0]);
     }
 }
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1,6 +1,6 @@
 extern crate term;
 use crate::piped_text;
-use crate::shared_functions::{ShellState, get_calc_vars};
+use crate::shared_functions::{ShellState, ShellCommand, PipedShellCommand, get_calc_vars};
 use std::io::prelude::*;
 
 fn calc_run(problem: &str) {
@@ -25,9 +25,9 @@ fn calc_return(problem: &str) -> i32 {
     }
 }
 
-pub fn calc(input: &str) {
-    let problem = input.split(' ').collect::<Vec<&str>>()[1].trim();
-    if input.contains('|') {
+pub fn calc(command: ShellCommand) {
+    let problem = command.args.concat();
+    /*if command.args.contains('|') {
         let calculation = calc_return(problem);
         let line_vector: Vec<&str> = input.split('|').collect();
         let cmd2 = line_vector[1];
@@ -38,9 +38,9 @@ pub fn calc(input: &str) {
         } else {
             piped_text(&calculation.to_string(), false, cmd2_with_args);
         }
-    } else {
-        calc_run(problem);
-    }
+    } else {*/
+
+    calc_run(&problem);
 }
 
 fn cd_helper(dir: &str) {
@@ -80,7 +80,7 @@ pub fn cd(shell_state: &mut ShellState, input: &str) {
 }
 
 pub fn echo(input: &str) {
-    if input.contains('|') {
+    /*if input.contains('|') {
         let line_vector: Vec<&str> = input.split('|').collect();
         let cmd = line_vector[0];
         let mut cmd_vector: Vec<&str> = cmd.split(' ').collect();
@@ -97,7 +97,7 @@ pub fn echo(input: &str) {
         } else {
             piped_text(&message, false, cmd2_with_args);
         }
-    } else {
+    } else {*/
         let input: Vec<&str> = input.split(' ').collect();
         let output = &input[1..];
         for arg in output {
@@ -105,7 +105,7 @@ pub fn echo(input: &str) {
             std::io::stdout().flush().unwrap();
         }
         println!();
-    }
+    //}
 }
 
 fn ls_do(input: &str) {
@@ -162,7 +162,7 @@ fn ls_do(input: &str) {
 pub fn ls(input: &str) {
     if input == "ls" {
         ls_do(".");
-    } else if input.contains('|') {
+    }/* else if input.contains('|') {
         let ls_input = input.split('|').collect::<Vec<&str>>()[0];
         let path = if ls_input.trim() == "ls" {
             std::fs::read_dir(".").unwrap()
@@ -198,8 +198,8 @@ pub fn ls(input: &str) {
         } else {
             let cmd: Vec<&str> = cmd.split(' ').collect();
             piped_text(&output, false, cmd);
-        }
-    } else {
+        }*/
+    else {
         let input = input.split(' ').collect::<Vec<&str>>()[1];
         ls_do(input);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use builtins::{calc, cd, echo, help, ls};
 #[cfg(feature = "readline")]
 use rustyline::{error::ReadlineError, Editor};
 use std::process::exit;
-use shared_functions::{cmd, ShellState, non_interactive, piped_cmd, piped_text};
+use shared_functions::{cmd, ShellState, ShellCommand, PipedShellCommand, non_interactive, piped_cmd, piped_text};
 
 #[cfg(not(feature = "readline"))]
 use shared_functions::parse_input;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 mod builtins;
 mod shared_functions;
 
-use builtins::{calc, cd, echo, help, ls};
 #[cfg(feature = "readline")]
 use rustyline::{error::ReadlineError, Editor};
 use std::process::exit;
@@ -12,25 +11,8 @@ use shared_functions::parse_input;
 
 // Process the input to run the appropriate builtin or external command.
 fn process_input(shell_state: &mut ShellState, input: String) {
-    if input.starts_with("calc") {
-        calc(&input);
-    } else if input.starts_with("cd") {
-        cd(shell_state, &input);
-    } else if input.starts_with("echo") {
-        echo(&input);
-    } else if input.starts_with("help") {
-        help();
-    } else if input.starts_with("ls") {
-        ls(&input);
-    } else if input == "pwd" {
-        println!("{}", std::env::current_dir().unwrap().display());
-    } else if input.contains('|') {
-        piped_cmd(&input);
-    } else if input.contains(' ') {
-        cmd(&input, true);
-    } else {
-        cmd(&input, false);
-    }
+    let command = ShellCommand::new(input);
+    ShellCommand::run(shell_state, command);
 }
 
 #[cfg(feature = "readline")]

--- a/src/shared_functions.rs
+++ b/src/shared_functions.rs
@@ -63,7 +63,7 @@ impl ShellCommand {
     pub fn run(shell_state: &mut ShellState, command: ShellCommand) {
         match command.name.as_str() {
             "calc" => calc(command),
-            "cd" => cd(shell_state, command.args),
+            "cd" => cd(shell_state, command),
             "echo" => echo(command),
             "help" => help(),
             "ls" => ls(command),

--- a/src/shared_functions.rs
+++ b/src/shared_functions.rs
@@ -1,6 +1,7 @@
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use crate::builtins::{calc, ls, help, echo, cd};
 
 /// Holds all important informations for and about the shell
 pub struct ShellState {

--- a/src/shared_functions.rs
+++ b/src/shared_functions.rs
@@ -180,23 +180,18 @@ pub fn parse_input(op: &str) -> String {
 }
 
 /// A function to pipe the output of one command into another.
-pub fn piped_cmd(input: &str) {
-    let input: Vec<&str> = input.split('|').collect();
-    let mut cmd1: Vec<&str> = input[0].split(' ').collect();
-    let mut cmd2: Vec<&str> = input[1].split(' ').collect();
-    cmd1.pop();
-    cmd2.remove(0);
-    let child1 = Command::new(cmd1[0])
-        .args(&cmd1[1..])
+pub fn piped_cmd(pipe: PipedShellCommand) {
+    let child1 = Command::new(pipe.commands[0].name.clone())
+        .args(&pipe.commands[0].args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .output()
         .or(Err(()));
     if child1.is_err() {
-        println!("Sorrry, '{}' was not found!", input[0]);
+        println!("Sorrry, '{}' was not found!", pipe.commands[0].name);
     } else {
-        let child2 = match Command::new(cmd2[0])
-            .args(&cmd2[1..])
+        let child2 = match Command::new(pipe.commands[1].name.clone())
+            .args(&pipe.commands[1].args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()

--- a/src/shared_functions.rs
+++ b/src/shared_functions.rs
@@ -118,25 +118,15 @@ impl PipedShellCommand {
 }
 
 /// Helper function to a command, optionally with args.
-pub fn cmd(input: &str, args: bool) {
-    if args {
-        let input: Vec<&str> = input.split(' ').collect();
-        let child = Command::new(&input[0])
-            .args(&input[1..])
-            .spawn()
-            .or(Err(()));
-        if child.is_err() {
-            println!("Sorry, '{}' was not found!", input[0]);
-        } else {
-            child.unwrap().wait().unwrap();
-        }
+pub fn cmd(command: ShellCommand) {
+    let child = Command::new(&command.name)
+        .args(&command.args)
+        .spawn()
+        .or(Err(()));
+    if child.is_err() {
+        println!("Sorry, '{}' was not found!", command.name);
     } else {
-        let child = Command::new(&input).spawn().or(Err(()));
-        if child.is_err() {
-            println!("Sorry, '{}' was not found!", input);
-        } else {
-            child.unwrap().wait().unwrap();
-        }
+        child.unwrap().wait().unwrap();
     }
 }
 


### PR DESCRIPTION
This PR introduces a ShellCommand struct, which is used to construct and execute commands, and is a setup for the next PR (though it can be used on it's own, but would have to rewrite some of it, to support everything), which refactors piping and allows to pipe more than two commands, as well as builtins, without the use of piped_text().
The ShellCommand struct also allows easier handling of arguments.