### PR TITLE
basic redirection with pipe support!

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -12,6 +12,15 @@ pub fn calc(args: Vec<String>) -> String {
         let command = ShellCommand {
             name: "calc".to_string(),
             args,
+            redirect: false,
+        };
+        let pipe = PipedShellCommand::from(command);
+        piped_cmd(pipe);
+    } else if args.contains(&">".to_string()) {
+        let command = ShellCommand {
+            name: "calc".to_string(),
+            args,
+            redirect: true,
         };
         let pipe = PipedShellCommand::from(command);
         piped_cmd(pipe);
@@ -76,6 +85,15 @@ pub fn echo(args: Vec<String>) -> String {
         let command = ShellCommand {
             name: "echo".to_string(),
             args,
+            redirect: false,
+        };
+        let pipe = PipedShellCommand::from(command);
+        piped_cmd(pipe);
+    } else if args.contains(&">".to_string()) {
+        let command = ShellCommand {
+            name: "echo".to_string(),
+            args,
+            redirect: true,
         };
         let pipe = PipedShellCommand::from(command);
         piped_cmd(pipe);
@@ -98,6 +116,15 @@ pub fn ls(mut args: Vec<String>) -> String {
         let command = ShellCommand {
             name: "ls".to_string(),
             args,
+            redirect: false,
+        };
+        let pipe = PipedShellCommand::from(command);
+        piped_cmd(pipe);
+    } else if args.contains(&">".to_string()) {
+        let command = ShellCommand {
+            name: "ls".to_string(),
+            args,
+            redirect: true,
         };
         let pipe = PipedShellCommand::from(command);
         piped_cmd(pipe);


### PR DESCRIPTION
This PR will remain a draft until it is deemed feature complete.

Currently, it has basic redirection with piping support.
Meaning you can pipe commands together, then redirect the final output to a file.

It doesn't run any check for if the file is writable (e.g. the parent dir doesn't exist yet), 
and it can only overwrite the hole file for now.